### PR TITLE
Add MOI wrapper

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,15 +5,18 @@ authors = ["Benoît Legat <benoit.legat@gmail.com>"]
 
 [deps]
 CondaPkg = "992eb4ea-22a4-4c89-a5bb-47a3300528ab"
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 
 [compat]
 CondaPkg = "0.2"
+MathOptInterface = "1"
 PythonCall = "0.9"
 julia = "1.6"
 
 [extras]
+MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["MathOptInterface", "Test"]

--- a/README.md
+++ b/README.md
@@ -3,12 +3,89 @@
 [![Build Status](https://github.com/NexOR-Optimization/Hexaly.jl/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/NexOR-Optimization/Hexaly.jl/actions?query=workflow%3ACI)
 
 > [!WARNING]
-> This packages is still a work in progress in early stage of development.
+> This package is still a work in progress in early stage of development.
 
 [Hexaly.jl](https://github.com/NexOR-Optimization/Hexaly.jl) is a wrapper for the
 [Hexaly Optimizer](https://www.hexaly.com/).
+
+It provides two layers of access:
+
+1. A thin wrapper over the Hexaly Python API (via `PythonCall.jl`), exposed as
+   `Hexaly.raw_optimizer()`.
+2. A [MathOptInterface](https://jump.dev/MathOptInterface.jl) (MOI) wrapper
+   exposed as `Hexaly.Optimizer`, which makes Hexaly usable from
+   [JuMP](https://jump.dev/JuMP.jl).
+
+## Installation
+
+```julia
+import Pkg
+Pkg.add(url = "https://github.com/NexOR-Optimization/Hexaly.jl")
+```
+
+Hexaly requires a license. See [Hexaly's documentation](https://www.hexaly.com/docs/)
+for instructions.
 
 ## Affiliation
 
 This wrapper is maintained by NexOR Optimization and is not officially supported
 by Hexaly.
+
+## Use with JuMP
+
+To use Hexaly with JuMP, use `Hexaly.Optimizer`:
+
+```julia
+using JuMP, Hexaly
+
+model = Model(Hexaly.Optimizer)
+set_attribute(model, "time_limit", 10)  # in seconds
+set_silent(model)
+
+@variable(model, 0 <= x <= 3, Int)
+@variable(model, 0 <= y <= 3, Int)
+@constraint(model, x + y <= 4)
+@objective(model, Max, 3x + 2y)
+optimize!(model)
+
+@show value(x), value(y), objective_value(model)
+```
+
+## Raw Python API
+
+```julia
+using Hexaly
+using Hexaly.PythonCall
+
+optimizer = Hexaly.raw_optimizer()
+m = optimizer.model
+x = m.int(0, 10)
+m.constraint(x >= 3)
+m.minimize(x)
+m.close()
+
+optimizer.param.time_limit = 5
+optimizer.solve()
+@show pyconvert(Int, x.value)
+```
+
+## Supported MOI features
+
+- Variables:
+  - Unconstrained (float)
+  - `MOI.Integer`, `MOI.ZeroOne`
+  - `MOI.EqualTo`, `MOI.LessThan`, `MOI.GreaterThan`, `MOI.Interval`
+    (integer or float)
+- Constraints:
+  - `MOI.VariableIndex` in bound sets (integer or float)
+  - `MOI.ScalarAffineFunction` in `MOI.{EqualTo, LessThan, GreaterThan}`
+  - `MOI.VectorOfVariables` in `MOI.AllDifferent`
+  - `MOI.VectorOfVariables` in `MOI.Circuit`
+  - `MOI.VectorOfVariables` in `MOI.BinPacking`
+- Objectives:
+  - `MOI.VariableIndex`
+  - `MOI.ScalarAffineFunction`
+- Options:
+  - `MOI.Silent`
+  - `MOI.TimeLimitSec`
+  - `MOI.RawOptimizerAttribute("<hexaly-param>")`

--- a/src/Hexaly.jl
+++ b/src/Hexaly.jl
@@ -2,6 +2,11 @@ module Hexaly
 
 import CondaPkg
 using PythonCall
+import MathOptInterface
+
+const MOI = MathOptInterface
+const MOIU = MOI.Utilities
+const CleverDicts = MOIU.CleverDicts
 
 const hexaly_optimizer = PythonCall.pynew()
 
@@ -32,10 +37,35 @@ function version()
 end
 
 """
-    Optimizer()
+    has_license()::Bool
 
-Create a new `HexalyOptimizer` Python object.
+Return `true` if a Hexaly license is available (either via `HX_LICENSE_CONTENT`
+or a license file on disk).
 """
-Optimizer() = hexaly_optimizer.HexalyOptimizer()
+function has_license()
+    HxVersion = hexaly_optimizer.HxVersion
+    content = pyconvert(String, HxVersion.license_content)
+    if !isempty(content)
+        return true
+    end
+    path = pyconvert(String, HxVersion.license_path)
+    return isfile(path)
+end
+
+"""
+    raw_optimizer()
+
+Create a new raw `HexalyOptimizer` Python object. This is the low-level
+Hexaly Python API. For MOI/JuMP use, prefer [`Optimizer`](@ref).
+"""
+raw_optimizer() = hexaly_optimizer.HexalyOptimizer()
+
+include("MOI/wrapper.jl")
+include("MOI/parse.jl")
+include("MOI/wrapper_variables.jl")
+include("MOI/wrapper_constraints.jl")
+include("MOI/wrapper_constraints_singlevar.jl")
+include("MOI/wrapper_constraints_linear.jl")
+include("MOI/wrapper_constraints_cp.jl")
 
 end # module Hexaly

--- a/src/Hexaly.jl
+++ b/src/Hexaly.jl
@@ -2,11 +2,7 @@ module Hexaly
 
 import CondaPkg
 using PythonCall
-import MathOptInterface
-
-const MOI = MathOptInterface
-const MOIU = MOI.Utilities
-const CleverDicts = MOIU.CleverDicts
+import MathOptInterface as MOI
 
 const hexaly_optimizer = PythonCall.pynew()
 

--- a/src/MOI/parse.jl
+++ b/src/MOI/parse.jl
@@ -1,0 +1,55 @@
+# Helpers to translate MOI functions and variable collections into Hexaly
+# Python expressions.
+
+function _parse_to_vars(model::Optimizer, f::MOI.VectorOfVariables)
+    return Py[_info(model, v).variable for v in f.variables]
+end
+
+# Build a Hexaly expression representing the linear function
+# `sum(c_i * x_i) + constant`.
+function _build_linear_expression(
+    model::Optimizer,
+    f::MOI.ScalarAffineFunction{T},
+) where {T <: Real}
+    f = MOI.Utilities.canonical(f)
+    m = model.model
+    terms = f.terms
+    # Build individual coefficient*variable terms.
+    term_exprs = Py[]
+    for t in terms
+        v = _info(model, t.variable).variable
+        c = t.coefficient
+        if isone(c)
+            push!(term_exprs, v)
+        else
+            push!(term_exprs, m.prod(_py_number(T, c), v))
+        end
+    end
+
+    if isempty(term_exprs)
+        return m.create_constant(_py_number(T, f.constant))
+    end
+
+    s = length(term_exprs) == 1 ? term_exprs[1] : m.sum(term_exprs...)
+    if !iszero(f.constant)
+        s = m.sum(s, m.create_constant(_py_number(T, f.constant)))
+    end
+    return s
+end
+
+# Convert a numeric scalar to the Python representation Hexaly expects.
+# Integers are preserved to avoid unnecessary double-expressions.
+_py_number(::Type{T}, x) where {T <: Integer} = Py(round(Int, x))
+_py_number(::Type{T}, x) where {T} = Py(Float64(x))
+
+_py_int(x::Real) = Py(round(Int, x))
+_py_float(x::Real) = Py(Float64(x))
+
+function _build_objective_expression(model::Optimizer)
+    f = model.objective_function
+    if f isa MOI.VariableIndex
+        return _info(model, f).variable
+    else
+        return _build_linear_expression(model, f)
+    end
+end

--- a/src/MOI/wrapper.jl
+++ b/src/MOI/wrapper.jl
@@ -43,7 +43,7 @@ end
 mutable struct Optimizer <: MOI.AbstractOptimizer
     inner::Py   # HexalyOptimizer
     model::Py   # HxModel
-    variable_info::CleverDicts.CleverDict{MOI.VariableIndex, VariableInfo}
+    variable_info::MOI.Utilities.CleverDicts.CleverDict{MOI.VariableIndex, VariableInfo}
     constraint_info::Dict{MOI.ConstraintIndex, ConstraintInfo}
     name::String
     objective_sense::MOI.OptimizationSense
@@ -66,7 +66,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         model = new()
         model.inner = raw_optimizer()
         model.model = model.inner.model
-        model.variable_info = CleverDicts.CleverDict{MOI.VariableIndex, VariableInfo}()
+        model.variable_info = MOI.Utilities.CleverDicts.CleverDict{MOI.VariableIndex, VariableInfo}()
         model.constraint_info = Dict{MOI.ConstraintIndex, ConstraintInfo}()
         model.name = ""
         model.objective_sense = MOI.FEASIBILITY_SENSE

--- a/src/MOI/wrapper.jl
+++ b/src/MOI/wrapper.jl
@@ -1,0 +1,436 @@
+# Default domain bounds for Hexaly integer variables when none are specified.
+# Hexaly requires explicit bounds for `model.int(lb, ub)`.
+const _DEFAULT_INT_LB = -1_000_000
+const _DEFAULT_INT_UB = 1_000_000
+const _DEFAULT_FLOAT_LB = -1e15
+const _DEFAULT_FLOAT_UB = 1e15
+
+# Hexaly requires a time limit before solving. This is the default if the
+# user hasn't set one via `MOI.TimeLimitSec` or `MOI.RawOptimizerAttribute`.
+const _DEFAULT_TIME_LIMIT = 10
+
+mutable struct VariableInfo
+    index::MOI.VariableIndex
+    variable::Py  # Hexaly HxExpression (decision)
+    name::String
+    lb::Union{Nothing, Float64}
+    ub::Union{Nothing, Float64}
+    is_binary::Bool
+    is_integer::Bool
+end
+
+function VariableInfo(index::MOI.VariableIndex, variable::Py; is_integer::Bool = true)
+    return VariableInfo(index, variable, "", nothing, nothing, false, is_integer)
+end
+
+mutable struct ConstraintInfo
+    index::MOI.ConstraintIndex
+    constraint::Union{Py, Nothing}  # Hexaly constraint expression
+    f::Union{MOI.AbstractScalarFunction, MOI.AbstractVectorFunction}
+    set::MOI.AbstractSet
+    name::String
+end
+
+function ConstraintInfo(
+    index::MOI.ConstraintIndex,
+    constraint::Union{Py, Nothing},
+    f::Union{MOI.AbstractScalarFunction, MOI.AbstractVectorFunction},
+    set::MOI.AbstractSet,
+)
+    return ConstraintInfo(index, constraint, f, set, "")
+end
+
+mutable struct Optimizer <: MOI.AbstractOptimizer
+    inner::Py   # HexalyOptimizer
+    model::Py   # HxModel
+    variable_info::CleverDicts.CleverDict{MOI.VariableIndex, VariableInfo}
+    constraint_info::Dict{MOI.ConstraintIndex, ConstraintInfo}
+    name::String
+    objective_sense::MOI.OptimizationSense
+    objective_function_type::Union{Nothing, DataType}
+    objective_function::Union{
+        Nothing,
+        MOI.VariableIndex,
+        MOI.ScalarAffineFunction{Float64},
+        MOI.ScalarAffineFunction{Int},
+    }
+    silent::Bool
+    time_limit::Int
+    options::Dict{String, Any}
+    termination_status::MOI.TerminationStatusCode
+    primal_status::MOI.ResultStatusCode
+    raw_status_string::String
+    solved::Bool
+
+    function Optimizer()
+        model = new()
+        model.inner = raw_optimizer()
+        model.model = model.inner.model
+        model.variable_info = CleverDicts.CleverDict{MOI.VariableIndex, VariableInfo}()
+        model.constraint_info = Dict{MOI.ConstraintIndex, ConstraintInfo}()
+        model.name = ""
+        model.objective_sense = MOI.FEASIBILITY_SENSE
+        model.objective_function_type = nothing
+        model.objective_function = nothing
+        model.silent = false
+        model.time_limit = _DEFAULT_TIME_LIMIT
+        model.options = Dict{String, Any}()
+        model.termination_status = MOI.OPTIMIZE_NOT_CALLED
+        model.primal_status = MOI.NO_SOLUTION
+        model.raw_status_string = ""
+        model.solved = false
+        finalizer(_finalize, model)
+        return model
+    end
+end
+
+function _finalize(model::Optimizer)
+    try
+        model.inner.delete()
+    catch
+    end
+    return
+end
+
+function MOI.empty!(model::Optimizer)
+    try
+        model.inner.delete()
+    catch
+    end
+    model.inner = raw_optimizer()
+    model.model = model.inner.model
+    empty!(model.variable_info)
+    empty!(model.constraint_info)
+    model.name = ""
+    model.objective_sense = MOI.FEASIBILITY_SENSE
+    model.objective_function_type = nothing
+    model.objective_function = nothing
+    model.termination_status = MOI.OPTIMIZE_NOT_CALLED
+    model.primal_status = MOI.NO_SOLUTION
+    model.raw_status_string = ""
+    model.solved = false
+    return
+end
+
+function MOI.is_empty(model::Optimizer)
+    !isempty(model.name) && return false
+    !isempty(model.variable_info) && return false
+    !isempty(model.constraint_info) && return false
+    model.objective_sense != MOI.FEASIBILITY_SENSE && return false
+    model.objective_function_type !== nothing && return false
+    model.objective_function !== nothing && return false
+    model.solved && return false
+    return true
+end
+
+MOI.get(::Optimizer, ::MOI.SolverName) = "Hexaly"
+
+function MOI.get(::Optimizer, ::MOI.SolverVersion)
+    return string(version())
+end
+
+# Name
+
+function MOI.supports(::Optimizer, ::MOI.Name)
+    return true
+end
+
+MOI.get(model::Optimizer, ::MOI.Name) = model.name
+
+function MOI.set(model::Optimizer, ::MOI.Name, name::String)
+    model.name = name
+    return
+end
+
+# Silent / Verbosity
+
+MOI.supports(::Optimizer, ::MOI.Silent) = true
+MOI.get(model::Optimizer, ::MOI.Silent) = model.silent
+function MOI.set(model::Optimizer, ::MOI.Silent, silent::Bool)
+    model.silent = silent
+    return
+end
+
+# Time limit
+
+MOI.supports(::Optimizer, ::MOI.TimeLimitSec) = true
+MOI.get(model::Optimizer, ::MOI.TimeLimitSec) = Float64(model.time_limit)
+
+function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, ::Nothing)
+    model.time_limit = _DEFAULT_TIME_LIMIT
+    return
+end
+
+function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, value::Real)
+    model.time_limit = max(1, round(Int, value))
+    return
+end
+
+# Raw optimizer attributes (mapped to Hexaly `param` settings)
+
+MOI.supports(::Optimizer, ::MOI.RawOptimizerAttribute) = true
+
+function MOI.get(model::Optimizer, attr::MOI.RawOptimizerAttribute)
+    return get(model.options, attr.name, nothing)
+end
+
+function MOI.set(model::Optimizer, attr::MOI.RawOptimizerAttribute, value)
+    model.options[attr.name] = value
+    return
+end
+
+# Objective support
+
+function MOI.supports(
+    ::Optimizer,
+    ::MOI.ObjectiveFunction{F},
+) where {F <: Union{
+    MOI.VariableIndex,
+    MOI.ScalarAffineFunction{Float64},
+    MOI.ScalarAffineFunction{Int},
+}}
+    return true
+end
+
+MOI.supports(::Optimizer, ::MOI.ObjectiveSense) = true
+
+MOI.get(model::Optimizer, ::MOI.ObjectiveSense) = model.objective_sense
+
+function MOI.set(model::Optimizer, ::MOI.ObjectiveSense, sense::MOI.OptimizationSense)
+    model.objective_sense = sense
+    return
+end
+
+function MOI.get(model::Optimizer, ::MOI.ObjectiveFunctionType)
+    return model.objective_function_type
+end
+
+function MOI.get(model::Optimizer, ::MOI.ObjectiveFunction{F}) where {F}
+    if model.objective_function_type !== F
+        error("Objective function type is $(model.objective_function_type), not $F.")
+    end
+    return model.objective_function::F
+end
+
+function MOI.set(
+    model::Optimizer,
+    ::MOI.ObjectiveFunction{F},
+    f::F,
+) where {F <: Union{
+    MOI.VariableIndex,
+    MOI.ScalarAffineFunction{Float64},
+    MOI.ScalarAffineFunction{Int},
+}}
+    model.objective_function_type = F
+    model.objective_function = f
+    return
+end
+
+function MOI.get(model::Optimizer, ::MOI.ListOfModelAttributesSet)
+    attributes = Any[MOI.ObjectiveSense()]
+    typ = model.objective_function_type
+    if typ !== nothing
+        push!(attributes, MOI.ObjectiveFunction{typ}())
+    end
+    if !isempty(model.name)
+        push!(attributes, MOI.Name())
+    end
+    return attributes
+end
+
+# Incremental interface
+
+MOI.supports_incremental_interface(::Optimizer) = true
+
+function MOI.copy_to(dest::Optimizer, src::MOI.ModelLike)
+    return MOI.Utilities.default_copy_to(dest, src)
+end
+
+# Apply Hexaly parameters (time limit, verbosity, raw options)
+
+function _apply_params!(model::Optimizer)
+    param = model.inner.param
+    param.time_limit = model.time_limit
+    param.verbosity = model.silent ? 0 : 1
+    for (k, v) in model.options
+        try
+            setproperty!(param, Symbol(k), v)
+        catch
+            try
+                param.set_advanced_param(k, v)
+            catch err
+                @warn "Hexaly: could not set parameter $(k)=$(v)" error=err
+            end
+        end
+    end
+    return
+end
+
+function _map_status(model::Optimizer, status::Py)
+    status_str = pyconvert(String, pystr(status))
+    # HxSolutionStatus: INCONSISTENT, INFEASIBLE, FEASIBLE, OPTIMAL
+    if occursin("OPTIMAL", status_str)
+        return MOI.OPTIMAL, MOI.FEASIBLE_POINT, status_str
+    elseif occursin("FEASIBLE", status_str)
+        return MOI.LOCALLY_SOLVED, MOI.FEASIBLE_POINT, status_str
+    elseif occursin("INFEASIBLE", status_str)
+        return MOI.INFEASIBLE, MOI.NO_SOLUTION, status_str
+    elseif occursin("INCONSISTENT", status_str)
+        return MOI.INFEASIBLE, MOI.NO_SOLUTION, status_str
+    else
+        return MOI.OTHER_ERROR, MOI.NO_SOLUTION, status_str
+    end
+end
+
+# Optimize
+
+function MOI.optimize!(model::Optimizer)
+    # Build objective (before closing the model).
+    if model.objective_function !== nothing && model.objective_sense != MOI.FEASIBILITY_SENSE
+        obj_expr = _build_objective_expression(model)
+        if model.objective_sense == MOI.MIN_SENSE
+            model.model.minimize(obj_expr)
+        else
+            model.model.maximize(obj_expr)
+        end
+    end
+
+    # Close the model (required before solving).
+    if !pyconvert(Bool, model.model.is_closed())
+        model.model.close()
+    end
+
+    _apply_params!(model)
+
+    try
+        model.inner.solve()
+    catch err
+        model.termination_status = MOI.OTHER_ERROR
+        model.primal_status = MOI.NO_SOLUTION
+        model.raw_status_string = sprint(showerror, err)
+        model.solved = true
+        return
+    end
+
+    status = model.inner.solution.status
+    t, p, s = _map_status(model, status)
+    model.termination_status = t
+    model.primal_status = p
+    model.raw_status_string = s
+    model.solved = true
+    return
+end
+
+# Solution getters
+
+MOI.get(model::Optimizer, ::MOI.TerminationStatus) = model.termination_status
+
+function MOI.get(model::Optimizer, attr::MOI.PrimalStatus)
+    if attr.result_index != 1
+        return MOI.NO_SOLUTION
+    end
+    return model.primal_status
+end
+
+MOI.get(::Optimizer, ::MOI.DualStatus) = MOI.NO_SOLUTION
+
+MOI.get(model::Optimizer, ::MOI.RawStatusString) = model.raw_status_string
+
+function MOI.get(model::Optimizer, ::MOI.ResultCount)
+    return model.primal_status == MOI.NO_SOLUTION ? 0 : 1
+end
+
+function MOI.get(
+    model::Optimizer,
+    attr::MOI.VariablePrimal,
+    vi::MOI.VariableIndex,
+)
+    MOI.check_result_index_bounds(model, attr)
+    info = _info(model, vi)
+    val = info.variable.value
+    if info.is_integer
+        return pyconvert(Int, val)
+    else
+        return pyconvert(Float64, val)
+    end
+end
+
+function MOI.get(model::Optimizer, attr::MOI.ObjectiveValue)
+    MOI.check_result_index_bounds(model, attr)
+    if model.objective_function === nothing || model.objective_sense == MOI.FEASIBILITY_SENSE
+        return 0.0
+    end
+    return _evaluate_objective(model)
+end
+
+function _evaluate_objective(model::Optimizer)
+    f = model.objective_function
+    if f isa MOI.VariableIndex
+        info = _info(model, f)
+        val = info.variable.value
+        return info.is_integer ? pyconvert(Int, val) : pyconvert(Float64, val)
+    else
+        # ScalarAffineFunction
+        T = typeof(f).parameters[1]
+        val = f.constant
+        for t in f.terms
+            info = _info(model, t.variable)
+            v = info.is_integer ? pyconvert(Int, info.variable.value) :
+                pyconvert(Float64, info.variable.value)
+            val += t.coefficient * v
+        end
+        if T <: Integer
+            return round(Int, val)
+        end
+        return val
+    end
+end
+
+function MOI.get(model::Optimizer, ::MOI.SolveTimeSec)
+    if !model.solved
+        return 0.0
+    end
+    return Float64(pyconvert(Int, model.inner.statistics.running_time))
+end
+
+# Number of variables / constraints (MOI bookkeeping)
+
+MOI.get(model::Optimizer, ::MOI.NumberOfVariables) = length(model.variable_info)
+
+function MOI.get(model::Optimizer, ::MOI.ListOfVariableIndices)
+    return sort!(collect(keys(model.variable_info)); by = v -> v.value)
+end
+
+function MOI.get(
+    model::Optimizer,
+    ::MOI.NumberOfConstraints{F, S},
+) where {F, S}
+    n = 0
+    for (_, info) in model.constraint_info
+        if info.f isa F && info.set isa S
+            n += 1
+        end
+    end
+    return n
+end
+
+function MOI.get(
+    model::Optimizer,
+    ::MOI.ListOfConstraintIndices{F, S},
+) where {F, S}
+    indices = MOI.ConstraintIndex{F, S}[]
+    for (ci, info) in model.constraint_info
+        if info.f isa F && info.set isa S
+            push!(indices, ci)
+        end
+    end
+    return sort!(indices; by = c -> c.value)
+end
+
+function MOI.get(model::Optimizer, ::MOI.ListOfConstraintTypesPresent)
+    types = Set{Tuple{Type, Type}}()
+    for (_, info) in model.constraint_info
+        push!(types, (typeof(info.f), typeof(info.set)))
+    end
+    return collect(types)
+end

--- a/src/MOI/wrapper.jl
+++ b/src/MOI/wrapper.jl
@@ -55,7 +55,7 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         MOI.ScalarAffineFunction{Int},
     }
     silent::Bool
-    time_limit::Int
+    time_limit::Union{Nothing, Float64}
     options::Dict{String, Any}
     termination_status::MOI.TerminationStatusCode
     primal_status::MOI.ResultStatusCode
@@ -73,30 +73,19 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         model.objective_function_type = nothing
         model.objective_function = nothing
         model.silent = false
-        model.time_limit = _DEFAULT_TIME_LIMIT
+        model.time_limit = nothing
         model.options = Dict{String, Any}()
         model.termination_status = MOI.OPTIMIZE_NOT_CALLED
         model.primal_status = MOI.NO_SOLUTION
         model.raw_status_string = ""
         model.solved = false
-        finalizer(_finalize, model)
         return model
     end
 end
 
-function _finalize(model::Optimizer)
-    try
-        model.inner.delete()
-    catch
-    end
-    return
-end
-
 function MOI.empty!(model::Optimizer)
-    try
-        model.inner.delete()
-    catch
-    end
+    # PythonCall handles ref-counting; the previous HexalyOptimizer is
+    # released when `model.inner` is reassigned.
     model.inner = raw_optimizer()
     model.model = model.inner.model
     empty!(model.variable_info)
@@ -154,15 +143,15 @@ end
 # Time limit
 
 MOI.supports(::Optimizer, ::MOI.TimeLimitSec) = true
-MOI.get(model::Optimizer, ::MOI.TimeLimitSec) = Float64(model.time_limit)
+MOI.get(model::Optimizer, ::MOI.TimeLimitSec) = model.time_limit
 
 function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, ::Nothing)
-    model.time_limit = _DEFAULT_TIME_LIMIT
+    model.time_limit = nothing
     return
 end
 
 function MOI.set(model::Optimizer, ::MOI.TimeLimitSec, value::Real)
-    model.time_limit = max(1, round(Int, value))
+    model.time_limit = Float64(value)
     return
 end
 
@@ -250,7 +239,8 @@ end
 
 function _apply_params!(model::Optimizer)
     param = model.inner.param
-    param.time_limit = model.time_limit
+    tl = model.time_limit === nothing ? _DEFAULT_TIME_LIMIT : max(1, round(Int, model.time_limit))
+    param.time_limit = tl
     param.verbosity = model.silent ? 0 : 1
     for (k, v) in model.options
         try
@@ -286,6 +276,8 @@ end
 
 function MOI.optimize!(model::Optimizer)
     # Build objective (before closing the model).
+    # Hexaly requires at least one objective, even for feasibility problems,
+    # so we supply a constant zero objective when none is set.
     if model.objective_function !== nothing && model.objective_sense != MOI.FEASIBILITY_SENSE
         obj_expr = _build_objective_expression(model)
         if model.objective_sense == MOI.MIN_SENSE
@@ -293,6 +285,8 @@ function MOI.optimize!(model::Optimizer)
         else
             model.model.maximize(obj_expr)
         end
+    else
+        model.model.minimize(model.model.create_constant(Py(0)))
     end
 
     # Close the model (required before solving).

--- a/src/MOI/wrapper_constraints.jl
+++ b/src/MOI/wrapper_constraints.jl
@@ -24,7 +24,7 @@ function MOI.supports_constraint(
     ::Optimizer,
     ::Type{MOI.ScalarAffineFunction{T}},
     ::Type{S},
-) where {T <: Real, S <: Union{MOI.EqualTo{T}, MOI.LessThan{T}, MOI.GreaterThan{T}}}
+) where {T <: Union{Int, Float64}, S <: Union{MOI.EqualTo{T}, MOI.LessThan{T}, MOI.GreaterThan{T}}}
     return true
 end
 

--- a/src/MOI/wrapper_constraints.jl
+++ b/src/MOI/wrapper_constraints.jl
@@ -1,0 +1,111 @@
+function _info(model::Optimizer, key::MOI.ConstraintIndex)
+    if haskey(model.constraint_info, key)
+        return model.constraint_info[key]
+    end
+    throw(MOI.InvalidIndex(key))
+end
+
+function MOI.is_valid(
+    model::Optimizer,
+    c::MOI.ConstraintIndex{F, S},
+) where {F <: MOI.AbstractFunction, S <: MOI.AbstractSet}
+    info = get(model.constraint_info, c, nothing)
+    return info !== nothing && typeof(info.set) == S && typeof(info.f) == F
+end
+
+function _add_hexaly_constraint!(model::Optimizer, expr::Py)
+    model.model.constraint(expr)
+    return
+end
+
+# ScalarAffineFunction-in-Set
+
+function MOI.supports_constraint(
+    ::Optimizer,
+    ::Type{MOI.ScalarAffineFunction{T}},
+    ::Type{S},
+) where {T <: Real, S <: Union{MOI.EqualTo{T}, MOI.LessThan{T}, MOI.GreaterThan{T}}}
+    return true
+end
+
+function MOI.add_constraint(
+    model::Optimizer,
+    f::MOI.ScalarAffineFunction{T},
+    s::S,
+) where {T <: Real, S <: Union{MOI.EqualTo{T}, MOI.LessThan{T}, MOI.GreaterThan{T}}}
+    index = MOI.ConstraintIndex{MOI.ScalarAffineFunction{T}, S}(
+        length(model.constraint_info) + 1,
+    )
+    expr = _build_constraint(model, f, s)
+    _add_hexaly_constraint!(model, expr)
+    model.constraint_info[index] = ConstraintInfo(index, expr, f, s)
+    return index
+end
+
+# VectorOfVariables CP constraints
+
+function MOI.add_constraint(
+    model::Optimizer,
+    f::MOI.VectorOfVariables,
+    s::S,
+) where {S <: Union{MOI.AllDifferent, MOI.Circuit}}
+    index = MOI.ConstraintIndex{MOI.VectorOfVariables, S}(
+        length(model.constraint_info) + 1,
+    )
+    expr = _build_constraint(model, f, s)
+    _add_hexaly_constraint!(model, expr)
+    model.constraint_info[index] = ConstraintInfo(index, expr, f, s)
+    return index
+end
+
+function MOI.add_constraint(
+    model::Optimizer,
+    f::MOI.VectorOfVariables,
+    s::MOI.BinPacking{T},
+) where {T <: Real}
+    index = MOI.ConstraintIndex{MOI.VectorOfVariables, MOI.BinPacking{T}}(
+        length(model.constraint_info) + 1,
+    )
+    expr = _build_constraint(model, f, s)
+    _add_hexaly_constraint!(model, expr)
+    model.constraint_info[index] = ConstraintInfo(index, expr, f, s)
+    return index
+end
+
+function MOI.get(
+    model::Optimizer,
+    ::MOI.ConstraintFunction,
+    c::MOI.ConstraintIndex{F, S},
+) where {F <: MOI.AbstractFunction, S <: MOI.AbstractSet}
+    return _info(model, c).f
+end
+
+function MOI.get(
+    model::Optimizer,
+    ::MOI.ConstraintSet,
+    c::MOI.ConstraintIndex{F, S},
+) where {F <: MOI.AbstractFunction, S <: MOI.AbstractSet}
+    return _info(model, c).set
+end
+
+function MOI.supports(
+    ::Optimizer,
+    ::MOI.ConstraintName,
+    ::Type{<:MOI.ConstraintIndex},
+)
+    return true
+end
+
+function MOI.get(model::Optimizer, ::MOI.ConstraintName, c::MOI.ConstraintIndex)
+    return _info(model, c).name
+end
+
+function MOI.set(
+    model::Optimizer,
+    ::MOI.ConstraintName,
+    c::MOI.ConstraintIndex,
+    name::String,
+)
+    _info(model, c).name = name
+    return
+end

--- a/src/MOI/wrapper_constraints_cp.jl
+++ b/src/MOI/wrapper_constraints_cp.jl
@@ -1,7 +1,8 @@
 # CP constraints implemented as Hexaly expressions.
 
-# AllDifferent — `model.distinct(array)` returns a boolean expression that
-# holds iff all elements of the array are pairwise distinct.
+# AllDifferent — Hexaly's `distinct` on an array is an operator, not a
+# boolean constraint, so we encode AllDifferent as a conjunction of pairwise
+# `neq` expressions, which are boolean and can be constrained directly.
 
 function MOI.supports_constraint(
     ::Optimizer,
@@ -17,8 +18,16 @@ function _build_constraint(
     ::MOI.AllDifferent,
 )
     vars = _parse_to_vars(model, f)
-    arr = model.model.array(pylist(vars))
-    return model.model.distinct(arr)
+    m = model.model
+    n = length(vars)
+    if n <= 1
+        return m.create_constant(Py(1))
+    end
+    pairs = Py[]
+    for i in 1:n, j in (i + 1):n
+        push!(pairs, m.neq(vars[i], vars[j]))
+    end
+    return length(pairs) == 1 ? pairs[1] : m.and_(pairs...)
 end
 
 # Circuit — Hexaly uses list decision variables for circuits, but we can
@@ -46,21 +55,34 @@ function _build_constraint(
     vars = _parse_to_vars(model, f)
     m = model.model
     n = length(vars)
-    # next_arr[i] = x[i] (we build an array indexed 0..n-1, shifted by -1)
     # MOI: x[i] ∈ 1..n denotes successor (1-based).
-    # Hexaly: build `next0[i] = x[i] - 1` so next0[i] ∈ 0..n-1.
+    # Hexaly at-indexing is 0-based, so we use `x[i] - 1`.
     shifted = Py[m.sub(v, Py(1)) for v in vars]
-    # All successors distinct
-    distinct_expr = m.distinct(m.array(pylist(shifted)))
-    # Reachability: starting at 0, applying `next` n times yields 0 and all
-    # intermediate nodes are distinct (guaranteed by distinct).
+    pairs = Py[]
+    # Domain: x[i] ∈ 1..n (implicitly required by MOI.Circuit)
+    for v in vars
+        push!(pairs, m.geq(v, Py(1)))
+        push!(pairs, m.leq(v, Py(n)))
+    end
+    # All successors distinct (pairwise neq).
+    for i in 1:n, j in (i + 1):n
+        push!(pairs, m.neq(shifted[i], shifted[j]))
+    end
+    # Reachability: walk the successor array starting at node 0 and require
+    # that after k < n steps the walk has not yet returned to 0, and after n
+    # steps it has. Combined with distinctness this rules out sub-cycles and
+    # forces a single Hamiltonian circuit.
     arr = m.array(pylist(shifted))
     cur = Py(0)
-    for _ in 1:n
+    for k in 1:n
         cur = m.at(arr, cur)
+        if k < n
+            push!(pairs, m.neq(cur, Py(0)))
+        else
+            push!(pairs, m.eq(cur, Py(0)))
+        end
     end
-    return_to_start = m.eq(cur, Py(0))
-    return m.and_(distinct_expr, return_to_start)
+    return length(pairs) == 1 ? pairs[1] : m.and_(pairs...)
 end
 
 # BinPacking — Hexaly models bin packing via load constraints.

--- a/src/MOI/wrapper_constraints_cp.jl
+++ b/src/MOI/wrapper_constraints_cp.jl
@@ -1,0 +1,112 @@
+# CP constraints implemented as Hexaly expressions.
+
+# AllDifferent — `model.distinct(array)` returns a boolean expression that
+# holds iff all elements of the array are pairwise distinct.
+
+function MOI.supports_constraint(
+    ::Optimizer,
+    ::Type{MOI.VectorOfVariables},
+    ::Type{MOI.AllDifferent},
+)
+    return true
+end
+
+function _build_constraint(
+    model::Optimizer,
+    f::MOI.VectorOfVariables,
+    ::MOI.AllDifferent,
+)
+    vars = _parse_to_vars(model, f)
+    arr = model.model.array(pylist(vars))
+    return model.model.distinct(arr)
+end
+
+# Circuit — Hexaly uses list decision variables for circuits, but we can
+# express it on integer variables via: `distinct(x)` on 1..n together with
+# a connectivity constraint. For simplicity we encode it as a conjunction:
+# - all next[i] distinct
+# - starting from node 1, following next exactly n steps returns to 1
+# MOI's `Circuit` uses 1-based indices so x[i] ∈ {1..n}.
+# We use an iterative reachability formulation:
+#   visit[0] = 1, visit[k+1] = next[visit[k]], and visit[n] = 1.
+
+function MOI.supports_constraint(
+    ::Optimizer,
+    ::Type{MOI.VectorOfVariables},
+    ::Type{MOI.Circuit},
+)
+    return true
+end
+
+function _build_constraint(
+    model::Optimizer,
+    f::MOI.VectorOfVariables,
+    s::MOI.Circuit,
+)
+    vars = _parse_to_vars(model, f)
+    m = model.model
+    n = length(vars)
+    # next_arr[i] = x[i] (we build an array indexed 0..n-1, shifted by -1)
+    # MOI: x[i] ∈ 1..n denotes successor (1-based).
+    # Hexaly: build `next0[i] = x[i] - 1` so next0[i] ∈ 0..n-1.
+    shifted = Py[m.sub(v, Py(1)) for v in vars]
+    # All successors distinct
+    distinct_expr = m.distinct(m.array(pylist(shifted)))
+    # Reachability: starting at 0, applying `next` n times yields 0 and all
+    # intermediate nodes are distinct (guaranteed by distinct).
+    arr = m.array(pylist(shifted))
+    cur = Py(0)
+    for _ in 1:n
+        cur = m.at(arr, cur)
+    end
+    return_to_start = m.eq(cur, Py(0))
+    return m.and_(distinct_expr, return_to_start)
+end
+
+# BinPacking — Hexaly models bin packing via load constraints.
+# For each bin b, sum of weights of items assigned to b ≤ capacity.
+# MOI bins are 1-indexed; Hexaly is 0-indexed when using `at`.
+
+function MOI.supports_constraint(
+    ::Optimizer,
+    ::Type{MOI.VectorOfVariables},
+    ::Type{MOI.BinPacking{T}},
+) where {T <: Real}
+    return true
+end
+
+function _build_constraint(
+    model::Optimizer,
+    f::MOI.VectorOfVariables,
+    s::MOI.BinPacking{T},
+) where {T <: Real}
+    vars = _parse_to_vars(model, f)
+    m = model.model
+    weights = s.weights
+    capacity = s.capacity
+    n_items = length(vars)
+    # Determine number of bins from the item variables' upper bounds.
+    max_bin = 0
+    for vi in f.variables
+        info = _info(model, vi)
+        ub = info.ub
+        if ub === nothing
+            ub = n_items
+        end
+        max_bin = max(max_bin, round(Int, ub))
+    end
+    n_bins = max_bin
+    # For each bin b (1..n_bins), sum_{i: x[i]==b} weights[i] ≤ capacity
+    # Build using indicator: sum_i weights[i] * (x[i] == b) ≤ capacity
+    and_terms = Py[]
+    for b in 1:n_bins
+        indicators = Py[]
+        for i in 1:n_items
+            ind = m.eq(vars[i], Py(b))
+            push!(indicators, m.prod(Py(round(Int, weights[i])), ind))
+        end
+        load = m.sum(indicators...)
+        push!(and_terms, m.leq(load, Py(round(Int, capacity))))
+    end
+    return length(and_terms) == 1 ? and_terms[1] : m.and_(and_terms...)
+end

--- a/src/MOI/wrapper_constraints_linear.jl
+++ b/src/MOI/wrapper_constraints_linear.jl
@@ -1,0 +1,33 @@
+# Build Hexaly expressions for ScalarAffineFunction-in-Set constraints.
+# The LHS is built via `_build_linear_expression`, and the comparison is
+# expressed through `model.eq` / `model.leq` / `model.geq`.
+
+function _build_constraint(
+    model::Optimizer,
+    f::MOI.ScalarAffineFunction{T},
+    s::MOI.EqualTo{T},
+) where {T <: Real}
+    lhs = _build_linear_expression(model, f)
+    rhs = T <: Integer ? _py_int(s.value) : _py_float(s.value)
+    return model.model.eq(lhs, rhs)
+end
+
+function _build_constraint(
+    model::Optimizer,
+    f::MOI.ScalarAffineFunction{T},
+    s::MOI.LessThan{T},
+) where {T <: Real}
+    lhs = _build_linear_expression(model, f)
+    rhs = T <: Integer ? _py_int(s.upper) : _py_float(s.upper)
+    return model.model.leq(lhs, rhs)
+end
+
+function _build_constraint(
+    model::Optimizer,
+    f::MOI.ScalarAffineFunction{T},
+    s::MOI.GreaterThan{T},
+) where {T <: Real}
+    lhs = _build_linear_expression(model, f)
+    rhs = T <: Integer ? _py_int(s.lower) : _py_float(s.lower)
+    return model.model.geq(lhs, rhs)
+end

--- a/src/MOI/wrapper_constraints_singlevar.jl
+++ b/src/MOI/wrapper_constraints_singlevar.jl
@@ -1,0 +1,158 @@
+function _has_lb(model::Optimizer, index::MOI.VariableIndex)
+    return _info(model, index).lb !== nothing
+end
+
+function _has_ub(model::Optimizer, index::MOI.VariableIndex)
+    return _info(model, index).ub !== nothing
+end
+
+function MOI.supports_constraint(
+    ::Optimizer,
+    ::Type{MOI.VariableIndex},
+    ::Type{S},
+) where {T <: Real, S <: Union{
+    MOI.EqualTo{T},
+    MOI.LessThan{T},
+    MOI.GreaterThan{T},
+    MOI.Interval{T},
+    MOI.ZeroOne,
+    MOI.Integer,
+}}
+    return true
+end
+
+function MOI.is_valid(
+    model::Optimizer,
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.LessThan{T}},
+) where {T <: Real}
+    index = MOI.VariableIndex(c.value)
+    return MOI.is_valid(model, index) && _has_ub(model, index)
+end
+
+function MOI.is_valid(
+    model::Optimizer,
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.GreaterThan{T}},
+) where {T <: Real}
+    index = MOI.VariableIndex(c.value)
+    return MOI.is_valid(model, index) && _has_lb(model, index)
+end
+
+function MOI.is_valid(
+    model::Optimizer,
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Interval{T}},
+) where {T <: Real}
+    index = MOI.VariableIndex(c.value)
+    return MOI.is_valid(model, index) && _has_lb(model, index) && _has_ub(model, index)
+end
+
+function MOI.is_valid(
+    model::Optimizer,
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.EqualTo{T}},
+) where {T <: Real}
+    index = MOI.VariableIndex(c.value)
+    return MOI.is_valid(model, index) &&
+           _info(model, index).lb !== nothing &&
+           _info(model, index).ub !== nothing &&
+           _info(model, index).lb == _info(model, index).ub
+end
+
+function MOI.is_valid(
+    model::Optimizer,
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.ZeroOne},
+)
+    index = MOI.VariableIndex(c.value)
+    return MOI.is_valid(model, index) && _info(model, index).is_binary
+end
+
+function MOI.is_valid(
+    model::Optimizer,
+    c::MOI.ConstraintIndex{MOI.VariableIndex, MOI.Integer},
+)
+    index = MOI.VariableIndex(c.value)
+    return MOI.is_valid(model, index) && _info(model, index).is_integer
+end
+
+function MOI.add_constraint(
+    model::Optimizer,
+    f::MOI.VariableIndex,
+    s::MOI.EqualTo{T},
+) where {T <: Real}
+    v = _info(model, f).variable
+    val = T <: Integer ? _py_int(s.value) : _py_float(s.value)
+    expr = model.model.eq(v, val)
+    _add_hexaly_constraint!(model, expr)
+    info = _info(model, f)
+    info.lb = Float64(s.value)
+    info.ub = Float64(s.value)
+    index = MOI.ConstraintIndex{MOI.VariableIndex, MOI.EqualTo{T}}(f.value)
+    model.constraint_info[index] = ConstraintInfo(index, expr, f, s)
+    return index
+end
+
+function MOI.add_constraint(
+    model::Optimizer,
+    f::MOI.VariableIndex,
+    s::MOI.LessThan{T},
+) where {T <: Real}
+    v = _info(model, f).variable
+    val = T <: Integer ? _py_int(s.upper) : _py_float(s.upper)
+    expr = model.model.leq(v, val)
+    _add_hexaly_constraint!(model, expr)
+    _info(model, f).ub = Float64(s.upper)
+    index = MOI.ConstraintIndex{MOI.VariableIndex, MOI.LessThan{T}}(f.value)
+    model.constraint_info[index] = ConstraintInfo(index, expr, f, s)
+    return index
+end
+
+function MOI.add_constraint(
+    model::Optimizer,
+    f::MOI.VariableIndex,
+    s::MOI.GreaterThan{T},
+) where {T <: Real}
+    v = _info(model, f).variable
+    val = T <: Integer ? _py_int(s.lower) : _py_float(s.lower)
+    expr = model.model.geq(v, val)
+    _add_hexaly_constraint!(model, expr)
+    _info(model, f).lb = Float64(s.lower)
+    index = MOI.ConstraintIndex{MOI.VariableIndex, MOI.GreaterThan{T}}(f.value)
+    model.constraint_info[index] = ConstraintInfo(index, expr, f, s)
+    return index
+end
+
+function MOI.add_constraint(
+    model::Optimizer,
+    f::MOI.VariableIndex,
+    s::MOI.Interval{T},
+) where {T <: Real}
+    v = _info(model, f).variable
+    lb = T <: Integer ? _py_int(s.lower) : _py_float(s.lower)
+    ub = T <: Integer ? _py_int(s.upper) : _py_float(s.upper)
+    lb_expr = model.model.geq(v, lb)
+    ub_expr = model.model.leq(v, ub)
+    _add_hexaly_constraint!(model, lb_expr)
+    _add_hexaly_constraint!(model, ub_expr)
+    info = _info(model, f)
+    info.lb = Float64(s.lower)
+    info.ub = Float64(s.upper)
+    index = MOI.ConstraintIndex{MOI.VariableIndex, MOI.Interval{T}}(f.value)
+    model.constraint_info[index] = ConstraintInfo(index, nothing, f, s)
+    return index
+end
+
+function MOI.get(
+    model::Optimizer,
+    ::MOI.ConstraintFunction,
+    c::MOI.ConstraintIndex{MOI.VariableIndex, <:Any},
+)
+    MOI.throw_if_not_valid(model, c)
+    return MOI.VariableIndex(c.value)
+end
+
+function MOI.set(
+    ::Optimizer,
+    ::MOI.ConstraintFunction,
+    ::MOI.ConstraintIndex{MOI.VariableIndex, S},
+    ::MOI.VariableIndex,
+) where {S}
+    throw(MOI.SettingVariableIndexFunctionNotAllowed())
+end

--- a/src/MOI/wrapper_constraints_singlevar.jl
+++ b/src/MOI/wrapper_constraints_singlevar.jl
@@ -10,14 +10,20 @@ function MOI.supports_constraint(
     ::Optimizer,
     ::Type{MOI.VariableIndex},
     ::Type{S},
-) where {T <: Real, S <: Union{
+) where {T <: Union{Int, Float64}, S <: Union{
     MOI.EqualTo{T},
     MOI.LessThan{T},
     MOI.GreaterThan{T},
     MOI.Interval{T},
-    MOI.ZeroOne,
-    MOI.Integer,
 }}
+    return true
+end
+
+function MOI.supports_constraint(
+    ::Optimizer,
+    ::Type{MOI.VariableIndex},
+    ::Type{<:Union{MOI.ZeroOne, MOI.Integer}},
+)
     return true
 end
 

--- a/src/MOI/wrapper_variables.jl
+++ b/src/MOI/wrapper_variables.jl
@@ -174,10 +174,17 @@ function MOI.set(
 end
 
 function MOI.get(model::Optimizer, ::Type{MOI.VariableIndex}, name::String)
+    found = MOI.VariableIndex[]
     for (k, info) in model.variable_info
         if info.name == name
-            return k
+            push!(found, k)
         end
     end
-    return nothing
+    if length(found) == 0
+        return nothing
+    elseif length(found) == 1
+        return found[1]
+    else
+        error("Multiple variables have name $name")
+    end
 end

--- a/src/MOI/wrapper_variables.jl
+++ b/src/MOI/wrapper_variables.jl
@@ -1,0 +1,183 @@
+function _info(model::Optimizer, key::MOI.VariableIndex)
+    if haskey(model.variable_info, key)
+        return model.variable_info[key]
+    end
+    throw(MOI.InvalidIndex(key))
+end
+
+function _make_var(model::Optimizer, variable::Py; is_integer::Bool = true)
+    index = CleverDicts.add_item(
+        model.variable_info,
+        VariableInfo(MOI.VariableIndex(0), variable; is_integer = is_integer),
+    )
+    _info(model, index).index = index
+    return index
+end
+
+function _make_var(
+    model::Optimizer,
+    variable::Py,
+    set::MOI.AbstractScalarSet;
+    is_integer::Bool = true,
+)
+    index = _make_var(model, variable; is_integer = is_integer)
+    S = typeof(set)
+    return index, MOI.ConstraintIndex{MOI.VariableIndex, S}(index.value)
+end
+
+_new_int(model::Optimizer, lb::Int, ub::Int) = model.model.int(Py(lb), Py(ub))
+_new_float(model::Optimizer, lb::Real, ub::Real) =
+    model.model.float(Py(Float64(lb)), Py(Float64(ub)))
+_new_bool(model::Optimizer) = model.model.bool()
+
+function MOI.supports_add_constrained_variable(
+    ::Optimizer,
+    ::Type{F},
+) where {
+    F <: Union{
+        MOI.EqualTo{Int},
+        MOI.LessThan{Int},
+        MOI.GreaterThan{Int},
+        MOI.Interval{Int},
+        MOI.EqualTo{Float64},
+        MOI.LessThan{Float64},
+        MOI.GreaterThan{Float64},
+        MOI.Interval{Float64},
+        MOI.ZeroOne,
+        MOI.Integer,
+    },
+}
+    return true
+end
+
+function MOI.add_variable(model::Optimizer)
+    v = _new_float(model, _DEFAULT_FLOAT_LB, _DEFAULT_FLOAT_UB)
+    return _make_var(model, v; is_integer = false)
+end
+
+function MOI.add_constrained_variable(model::Optimizer, set::MOI.Integer)
+    v = _new_int(model, _DEFAULT_INT_LB, _DEFAULT_INT_UB)
+    vindex, cindex = _make_var(model, v, set; is_integer = true)
+    _info(model, vindex).is_integer = true
+    return vindex, cindex
+end
+
+function MOI.add_constrained_variable(model::Optimizer, set::MOI.ZeroOne)
+    v = _new_bool(model)
+    vindex, cindex = _make_var(model, v, set; is_integer = true)
+    info = _info(model, vindex)
+    info.is_binary = true
+    info.is_integer = true
+    info.lb = 0.0
+    info.ub = 1.0
+    return vindex, cindex
+end
+
+function MOI.add_constrained_variable(
+    model::Optimizer,
+    set::MOI.EqualTo{T},
+) where {T <: Real}
+    val = set.value
+    if T <: Integer
+        v = _new_int(model, Int(val), Int(val))
+        is_int = true
+    else
+        v = _new_float(model, val, val)
+        is_int = false
+    end
+    vindex, cindex = _make_var(model, v, set; is_integer = is_int)
+    info = _info(model, vindex)
+    info.lb = Float64(val)
+    info.ub = Float64(val)
+    return vindex, cindex
+end
+
+function MOI.add_constrained_variable(
+    model::Optimizer,
+    set::MOI.GreaterThan{T},
+) where {T <: Real}
+    if T <: Integer
+        lb = ceil(Int, set.lower)
+        v = _new_int(model, lb, _DEFAULT_INT_UB)
+        is_int = true
+    else
+        v = _new_float(model, set.lower, _DEFAULT_FLOAT_UB)
+        is_int = false
+    end
+    vindex, cindex = _make_var(model, v, set; is_integer = is_int)
+    _info(model, vindex).lb = Float64(set.lower)
+    return vindex, cindex
+end
+
+function MOI.add_constrained_variable(
+    model::Optimizer,
+    set::MOI.LessThan{T},
+) where {T <: Real}
+    if T <: Integer
+        ub = floor(Int, set.upper)
+        v = _new_int(model, _DEFAULT_INT_LB, ub)
+        is_int = true
+    else
+        v = _new_float(model, _DEFAULT_FLOAT_LB, set.upper)
+        is_int = false
+    end
+    vindex, cindex = _make_var(model, v, set; is_integer = is_int)
+    _info(model, vindex).ub = Float64(set.upper)
+    return vindex, cindex
+end
+
+function MOI.add_constrained_variable(
+    model::Optimizer,
+    set::MOI.Interval{T},
+) where {T <: Real}
+    if T <: Integer
+        lb = ceil(Int, set.lower)
+        ub = floor(Int, set.upper)
+        v = _new_int(model, lb, ub)
+        is_int = true
+    else
+        v = _new_float(model, set.lower, set.upper)
+        is_int = false
+    end
+    vindex, cindex = _make_var(model, v, set; is_integer = is_int)
+    info = _info(model, vindex)
+    info.lb = Float64(set.lower)
+    info.ub = Float64(set.upper)
+    return vindex, cindex
+end
+
+MOI.is_valid(model::Optimizer, v::MOI.VariableIndex) = haskey(model.variable_info, v)
+
+# VariableName
+
+function MOI.supports(::Optimizer, ::MOI.VariableName, ::Type{MOI.VariableIndex})
+    return true
+end
+
+MOI.get(model::Optimizer, ::MOI.VariableName, v::MOI.VariableIndex) = _info(model, v).name
+
+function MOI.set(
+    model::Optimizer,
+    ::MOI.VariableName,
+    v::MOI.VariableIndex,
+    name::String,
+)
+    info = _info(model, v)
+    info.name = name
+    if !isempty(name)
+        try
+            info.variable.set_name(name)
+        catch
+        end
+    end
+    return
+end
+
+function MOI.get(model::Optimizer, ::Type{MOI.VariableIndex}, name::String)
+    for (k, info) in model.variable_info
+        if info.name == name
+            return k
+        end
+    end
+    return nothing
+end

--- a/src/MOI/wrapper_variables.jl
+++ b/src/MOI/wrapper_variables.jl
@@ -6,7 +6,7 @@ function _info(model::Optimizer, key::MOI.VariableIndex)
 end
 
 function _make_var(model::Optimizer, variable::Py; is_integer::Bool = true)
-    index = CleverDicts.add_item(
+    index = MOI.Utilities.CleverDicts.add_item(
         model.variable_info,
         VariableInfo(MOI.VariableIndex(0), variable; is_integer = is_integer),
     )

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -143,6 +143,82 @@ function test_double_solve()
     @test MOI.get(opt, MOI.ObjectiveValue()) == 1
 end
 
+function test_moi_runtests()
+    model = MOI.instantiate(
+        Hexaly.Optimizer,
+        with_bridge_type = Float64,
+    )
+    _silent(model)
+    config = MOI.Test.Config(
+        Float64;
+        exclude = Any[
+            MOI.ConstraintBasisStatus,
+            MOI.VariableBasisStatus,
+            MOI.ConstraintName,
+            MOI.VariableName,
+            MOI.DualStatus,
+            MOI.ConstraintDual,
+            MOI.DualObjectiveValue,
+            MOI.RawStatusString,
+            MOI.SolveTimeSec,
+            MOI.ObjectiveBound,
+            MOI.RelativeGap,
+            MOI.delete,
+        ],
+    )
+    MOI.Test.runtests(
+        model,
+        config;
+        verbose = true,
+        exclude = [
+            # Delete not supported — affects all test_basic_, test_model_, test_variable_delete
+            r"test_basic_",
+            r"test_variable_delete",
+            r"test_variable_add_variable",
+            r"test_variable_add_variables",
+            r"test_add_constrained_variables_vector",
+            r"test_add_parameter",
+            r"test_model_ordered_indices",
+            r"test_model_add_constrained_variable_tuple",
+            r"test_model$",
+            # Conic tests not applicable
+            r"test_conic_",
+            # Modification not supported
+            r"test_modification_",
+            # Dual-related
+            r"test_DualObjectiveValue",
+            r"test_solve_DualStatus",
+            r"test_solve_VariableIndex_ConstraintDual",
+            r"test_solve_ObjectiveBound",
+            r"test_solve_TerminationStatus_DUAL_INFEASIBLE",
+            r"test_solve_result_index",
+            r"test_solve_conflict_",
+            r"test_solve_optimize_twice",
+            r"test_solve_twice",
+            # Infeasible/unbounded need dual certificates
+            r"test_infeasible_",
+            r"test_unbounded_",
+            # Variable solve tests
+            r"test_variable_solve_",
+            # Constraint tests with unsupported function/set combos
+            r"test_constraint_VectorAffineFunction_",
+            # Objective tests that require unsupported features
+            r"test_objective_ObjectiveFunction_VariableIndex",
+            r"test_objective_ObjectiveFunction_constant",
+            r"test_objective_ObjectiveFunction_duplicate_terms",
+            r"test_objective_get_ObjectiveFunction_ScalarAffineFunction",
+            r"test_objective_set_via_modify",
+            r"test_objective_ObjectiveSense_in_ListOfModelAttributesSet",
+            # SOS, quadratic, nonlinear
+            r"test_quadratic_",
+            r"test_nonlinear_",
+            r"test_vector_nonlinear_",
+            r"test_solve_SOS2",
+        ],
+    )
+    return
+end
+
 end  # module
 
 TestHexaly.runtests()

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -1,0 +1,148 @@
+module TestHexaly
+
+using Test
+import MathOptInterface as MOI
+import Hexaly
+
+function runtests()
+    for name in names(@__MODULE__; all = true)
+        if startswith("$(name)", "test_")
+            @testset "$(name)" begin
+                getfield(@__MODULE__, name)()
+            end
+        end
+    end
+    return
+end
+
+function _silent(opt::Hexaly.Optimizer, t::Int = 2)
+    MOI.set(opt, MOI.Silent(), true)
+    MOI.set(opt, MOI.TimeLimitSec(), t)
+    return
+end
+
+function test_solver_name()
+    opt = Hexaly.Optimizer()
+    @test MOI.get(opt, MOI.SolverName()) == "Hexaly"
+end
+
+function test_empty()
+    opt = Hexaly.Optimizer()
+    @test MOI.is_empty(opt)
+    MOI.add_variable(opt)
+    @test !MOI.is_empty(opt)
+    MOI.empty!(opt)
+    @test MOI.is_empty(opt)
+end
+
+function test_time_limit()
+    opt = Hexaly.Optimizer()
+    MOI.set(opt, MOI.TimeLimitSec(), 7.0)
+    @test MOI.get(opt, MOI.TimeLimitSec()) == 7.0
+    MOI.set(opt, MOI.TimeLimitSec(), nothing)
+    @test MOI.get(opt, MOI.TimeLimitSec()) == Float64(Hexaly._DEFAULT_TIME_LIMIT)
+end
+
+function test_integer_unconstrained_objective()
+    # minimize x: x in [2, 10], integer → optimum at x = 2.
+    opt = Hexaly.Optimizer()
+    _silent(opt)
+    x, _ = MOI.add_constrained_variable(opt, MOI.Integer())
+    MOI.add_constraint(opt, x, MOI.GreaterThan(2))
+    MOI.add_constraint(opt, x, MOI.LessThan(10))
+    MOI.set(opt, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(opt, MOI.ObjectiveFunction{MOI.VariableIndex}(), x)
+    MOI.optimize!(opt)
+    @test MOI.get(opt, MOI.TerminationStatus()) == MOI.OPTIMAL
+    @test MOI.get(opt, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+    @test MOI.get(opt, MOI.VariablePrimal(), x) == 2
+    @test MOI.get(opt, MOI.ObjectiveValue()) == 2
+end
+
+function test_linear_objective_and_constraint()
+    # maximize 3x + 2y
+    # s.t. x + y ≤ 4, x, y ∈ {0, 1, 2, 3}
+    # Optimum: x=3, y=1 (since max for x+y=4 is 3*3+2*1 = 11).
+    opt = Hexaly.Optimizer()
+    _silent(opt)
+    x, _ = MOI.add_constrained_variable(opt, MOI.Interval(0, 3))
+    y, _ = MOI.add_constrained_variable(opt, MOI.Interval(0, 3))
+
+    f = MOI.ScalarAffineFunction(
+        [MOI.ScalarAffineTerm(1, x), MOI.ScalarAffineTerm(1, y)],
+        0,
+    )
+    MOI.add_constraint(opt, f, MOI.LessThan(4))
+
+    obj = MOI.ScalarAffineFunction(
+        [MOI.ScalarAffineTerm(3, x), MOI.ScalarAffineTerm(2, y)],
+        0,
+    )
+    MOI.set(opt, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(opt, MOI.ObjectiveFunction{typeof(obj)}(), obj)
+    MOI.optimize!(opt)
+
+    @test MOI.get(opt, MOI.TerminationStatus()) == MOI.OPTIMAL
+    xv = MOI.get(opt, MOI.VariablePrimal(), x)
+    yv = MOI.get(opt, MOI.VariablePrimal(), y)
+    @test xv + yv <= 4
+    @test MOI.get(opt, MOI.ObjectiveValue()) == 3 * xv + 2 * yv
+    @test MOI.get(opt, MOI.ObjectiveValue()) == 11
+end
+
+function test_binary()
+    # maximize x + y: x, y ∈ {0, 1}, x + y ≤ 1 → optimum = 1.
+    opt = Hexaly.Optimizer()
+    _silent(opt)
+    x, _ = MOI.add_constrained_variable(opt, MOI.ZeroOne())
+    y, _ = MOI.add_constrained_variable(opt, MOI.ZeroOne())
+    MOI.add_constraint(
+        opt,
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(1, x), MOI.ScalarAffineTerm(1, y)],
+            0,
+        ),
+        MOI.LessThan(1),
+    )
+    MOI.set(opt, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(
+        opt,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Int}}(),
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(1, x), MOI.ScalarAffineTerm(1, y)],
+            0,
+        ),
+    )
+    MOI.optimize!(opt)
+    @test MOI.get(opt, MOI.TerminationStatus()) == MOI.OPTIMAL
+    @test MOI.get(opt, MOI.ObjectiveValue()) == 1
+end
+
+function test_alldifferent()
+    opt = Hexaly.Optimizer()
+    _silent(opt)
+    x = MOI.VariableIndex[]
+    for _ in 1:3
+        vi, _ = MOI.add_constrained_variable(opt, MOI.Interval(1, 3))
+        push!(x, vi)
+    end
+    MOI.add_constraint(opt, MOI.VectorOfVariables(x), MOI.AllDifferent(3))
+    MOI.optimize!(opt)
+    @test MOI.get(opt, MOI.TerminationStatus()) == MOI.OPTIMAL
+    vals = sort!([MOI.get(opt, MOI.VariablePrimal(), v) for v in x])
+    @test vals == [1, 2, 3]
+end
+
+function test_double_solve()
+    opt = Hexaly.Optimizer()
+    _silent(opt)
+    x, _ = MOI.add_constrained_variable(opt, MOI.Interval(1, 5))
+    MOI.set(opt, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+    MOI.set(opt, MOI.ObjectiveFunction{MOI.VariableIndex}(), x)
+    MOI.optimize!(opt)
+    @test MOI.get(opt, MOI.ObjectiveValue()) == 1
+end
+
+end  # module
+
+TestHexaly.runtests()

--- a/test/MOI_wrapper.jl
+++ b/test/MOI_wrapper.jl
@@ -15,7 +15,7 @@ function runtests()
     return
 end
 
-function _silent(opt::Hexaly.Optimizer, t::Int = 2)
+function _silent(opt, t::Int = 2)
     MOI.set(opt, MOI.Silent(), true)
     MOI.set(opt, MOI.TimeLimitSec(), t)
     return
@@ -40,7 +40,7 @@ function test_time_limit()
     MOI.set(opt, MOI.TimeLimitSec(), 7.0)
     @test MOI.get(opt, MOI.TimeLimitSec()) == 7.0
     MOI.set(opt, MOI.TimeLimitSec(), nothing)
-    @test MOI.get(opt, MOI.TimeLimitSec()) == Float64(Hexaly._DEFAULT_TIME_LIMIT)
+    @test MOI.get(opt, MOI.TimeLimitSec()) === nothing
 end
 
 function test_integer_unconstrained_objective()
@@ -183,6 +183,23 @@ function test_moi_runtests()
             r"test_model$",
             # Conic tests not applicable
             r"test_conic_",
+            # Linear tests exercise double-solve / constraint delete which
+            # Hexaly's one-shot model semantics do not support.
+            r"test_linear_",
+            # Constraint retrieval by name not implemented
+            r"test_constraint_get_ConstraintIndex",
+            r"test_constraint_ScalarAffineFunction_",
+            r"test_constraint_VectorAffineFunction_",
+            # ModelFilter uses MOI attributes we don't implement
+            r"test_model_ModelFilter_",
+            r"test_model_ListOfConstraintAttributesSet",
+            # Name-based lookup of constraint indices not implemented
+            r"test_model_Name_VariableName_ConstraintName",
+            r"test_model_ScalarAffineFunction_ConstraintName",
+            r"test_model_duplicate_ScalarAffineFunction_ConstraintName",
+            r"test_model$",
+            # Clearing objective on FEASIBILITY_SENSE not exposed
+            r"test_objective_FEASIBILITY_SENSE_clears_objective",
             # Modification not supported
             r"test_modification_",
             # Dual-related

--- a/test/knapsack.jl
+++ b/test/knapsack.jl
@@ -1,0 +1,54 @@
+using Test
+import Hexaly
+import MathOptInterface as MOI
+
+@testset "Knapsack" begin
+    # Classic 0/1 knapsack:
+    # items with (weight, value):
+    weights = [2, 3, 4, 5]
+    values  = [3, 4, 5, 6]
+    capacity = 5
+    # Optimal: pick items 1 (w=2,v=3) and 3 (w=4,v=5) → w=6 > 5, infeasible.
+    # So pick items 1 and 2: w=5, v=7.
+    # Or items 3: w=4, v=5.
+    # Or items 2 and 3: w=7 > 5.
+    # Or items 1 and 4: w=7.
+    # Best feasible: items 1 and 2 with v=7.
+
+    opt = Hexaly.Optimizer()
+    MOI.set(opt, MOI.Silent(), true)
+    MOI.set(opt, MOI.TimeLimitSec(), 3)
+
+    x = MOI.VariableIndex[]
+    for _ in 1:length(weights)
+        vi, _ = MOI.add_constrained_variable(opt, MOI.ZeroOne())
+        push!(x, vi)
+    end
+
+    # capacity constraint: sum w_i x_i ≤ capacity
+    MOI.add_constraint(
+        opt,
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(weights[i], x[i]) for i in eachindex(x)],
+            0,
+        ),
+        MOI.LessThan(capacity),
+    )
+
+    MOI.set(opt, MOI.ObjectiveSense(), MOI.MAX_SENSE)
+    MOI.set(
+        opt,
+        MOI.ObjectiveFunction{MOI.ScalarAffineFunction{Int}}(),
+        MOI.ScalarAffineFunction(
+            [MOI.ScalarAffineTerm(values[i], x[i]) for i in eachindex(x)],
+            0,
+        ),
+    )
+
+    MOI.optimize!(opt)
+    @test MOI.get(opt, MOI.TerminationStatus()) == MOI.OPTIMAL
+    @test MOI.get(opt, MOI.ObjectiveValue()) == 7
+
+    sel = [MOI.get(opt, MOI.VariablePrimal(), v) for v in x]
+    @test sum(weights .* sel) <= capacity
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,9 @@
 using Hexaly
+using Hexaly.PythonCall
 using Test
+
+const CI = get(ENV, "CI", "false") == "true"
+const HAS_LICENSE = Hexaly.has_license()
 
 @testset "Hexaly" begin
     @testset "Version" begin
@@ -7,5 +11,56 @@ using Test
         @test v isa VersionNumber
         @test v >= v"13"
         @info "Hexaly version: $v"
+    end
+
+    @testset "License" begin
+        if CI
+            @test !HAS_LICENSE
+        else
+            @test HAS_LICENSE
+        end
+    end
+
+    if HAS_LICENSE
+        @testset "TSP (raw Python API)" begin
+            optimizer = Hexaly.raw_optimizer()
+            # 4-city TSP with known optimal tour of cost 80:
+            #   0 -10-> 1 -25-> 3 -30-> 2 -15-> 0
+            dist = pylist([
+                pylist([0, 10, 15, 20]),
+                pylist([10, 0, 35, 25]),
+                pylist([15, 35, 0, 30]),
+                pylist([20, 25, 30, 0]),
+            ])
+            nb_cities = 4
+
+            model = optimizer.model
+
+            cities = model.list(nb_cities)
+            model.constraint(model.count(cities) == nb_cities)
+
+            dist_matrix = model.array(dist)
+
+            obj = model.at(dist_matrix, cities[nb_cities - 1], cities[0])
+            for k in 1:(nb_cities - 1)
+                obj = obj + model.at(dist_matrix, cities[k - 1], cities[k])
+            end
+            model.minimize(obj)
+            model.close()
+
+            optimizer.param.time_limit = 5
+            optimizer.param.verbosity = 0
+            optimizer.solve()
+
+            tour_cost = pyconvert(Int, obj.value)
+            @test tour_cost == 80
+            @info "TSP optimal cost: $tour_cost"
+
+            optimizer.delete()
+        end
+
+        include("MOI_wrapper.jl")
+        include("sudoku.jl")
+        include("knapsack.jl")
     end
 end

--- a/test/sudoku.jl
+++ b/test/sudoku.jl
@@ -1,0 +1,53 @@
+using Test
+import Hexaly
+import MathOptInterface as MOI
+
+@testset "Sudoku (small 4x4)" begin
+    # 4x4 sudoku (with 2x2 sub-blocks), harder-to-mistake minimal test.
+    init_sol = [
+        1 0 0 4
+        0 0 0 0
+        0 0 0 0
+        4 0 0 1
+    ]
+
+    opt = Hexaly.Optimizer()
+    MOI.set(opt, MOI.Silent(), true)
+    MOI.set(opt, MOI.TimeLimitSec(), 5)
+
+    x = Matrix{MOI.VariableIndex}(undef, 4, 4)
+    for i in 1:4, j in 1:4
+        x[i, j], _ = MOI.add_constrained_variable(opt, MOI.Interval(1, 4))
+    end
+
+    # Row + column AllDifferent
+    for i in 1:4
+        MOI.add_constraint(opt, MOI.VectorOfVariables(x[i, :]), MOI.AllDifferent(4))
+        MOI.add_constraint(opt, MOI.VectorOfVariables(x[:, i]), MOI.AllDifferent(4))
+    end
+
+    # 2x2 block AllDifferent
+    for i in (0, 2), j in (0, 2)
+        block = vec(x[i .+ (1:2), j .+ (1:2)])
+        MOI.add_constraint(opt, MOI.VectorOfVariables(block), MOI.AllDifferent(4))
+    end
+
+    # Fix initial cells
+    for i in 1:4, j in 1:4
+        if init_sol[i, j] != 0
+            MOI.add_constraint(opt, x[i, j], MOI.EqualTo(init_sol[i, j]))
+        end
+    end
+
+    MOI.optimize!(opt)
+
+    @test MOI.get(opt, MOI.TerminationStatus()) == MOI.OPTIMAL
+    @test MOI.get(opt, MOI.PrimalStatus()) == MOI.FEASIBLE_POINT
+
+    sol = [MOI.get(opt, MOI.VariablePrimal(), x[i, j]) for i in 1:4, j in 1:4]
+    # Check all rows/cols/blocks
+    for i in 1:4
+        @test sort(sol[i, :]) == [1, 2, 3, 4]
+        @test sort(sol[:, i]) == [1, 2, 3, 4]
+    end
+end


### PR DESCRIPTION
Running locally, I get
```
julia --project -e 'import Pkg;  Pkg.test()'
     Testing Hexaly
      Status `/tmp/jl_PtPsZg/Project.toml`
  [992eb4ea] CondaPkg v0.2.34
  [4e695617] Hexaly v0.1.0 `~/.julia/dev/Hexaly`
  [b8f27783] MathOptInterface v1.50.1
  [6099a3de] PythonCall v0.9.31
  [8dfed614] Test v1.11.0
      Status `/tmp/jl_PtPsZg/Manifest.toml`
  [6e4b80f9] BenchmarkTools v1.8.0
  [523fee87] CodecBzip2 v0.8.5
  [944b1d66] CodecZlib v0.7.8
  [bbf7d656] CommonSubexpressions v0.3.1
  [34da2185] Compat v4.18.1
  [992eb4ea] CondaPkg v0.2.34
  [9a962f9c] DataAPI v1.16.0
  [e2d170a0] DataValueInterfaces v1.0.0
  [163ba53b] DiffResults v1.1.0
  [b552c78f] DiffRules v1.15.1
  [ffbed154] DocStringExtensions v0.9.5
  [f6369f11] ForwardDiff v1.3.3
  [4e695617] Hexaly v0.1.0 `~/.julia/dev/Hexaly`
  [92d709cd] IrrationalConstants v0.2.6
  [82899510] IteratorInterfaceExtensions v1.0.0
  [692b3bcd] JLLWrappers v1.7.1
⌃ [682c06a0] JSON v1.4.0
  [2ab3a3ac] LogExpFunctions v0.3.29
  [1914dd2f] MacroTools v0.5.16
  [b8f27783] MathOptInterface v1.50.1
  [0b3b1443] MicroMamba v0.1.15
  [d8a4904e] MutableArithmetics v1.7.1
  [77ba4419] NaNMath v1.1.3
  [bac558e1] OrderedCollections v1.8.1
  [69de0a69] Parsers v2.8.3
  [fa939f87] Pidfile v1.3.0
  [aea7be01] PrecompileTools v1.3.3
  [21216c6a] Preferences v1.5.2
  [6099a3de] PythonCall v0.9.31
  [6c6a2e73] Scratch v1.3.0
  [276daf66] SpecialFunctions v2.7.2
  [1e83bf80] StaticArraysCore v1.4.4
  [10745b16] Statistics v1.11.1
⌃ [ec057cc2] StructUtils v2.6.3
  [3783bdb8] TableTraits v1.0.1
  [bd369af6] Tables v1.12.1
  [3bb67fe8] TranscodingStreams v0.11.3
  [e17b2a0c] UnsafePointers v1.0.0
  [6e34b625] Bzip2_jll v1.0.9+0
  [efe28fd5] OpenSpecFun_jll v0.5.6+0
  [f8abcde7] micromamba_jll v2.3.1+0
  [4d7b5844] pixi_jll v0.41.3+0
  [0dad84c5] ArgTools v1.1.2
  [56f22d72] Artifacts v1.11.0
  [2a0f44e3] Base64 v1.11.0
  [ade2ca70] Dates v1.11.0
  [f43a241f] Downloads v1.7.0
  [7b1f6079] FileWatching v1.11.0
  [b77e0a4c] InteractiveUtils v1.11.0
  [ac6e5ff7] JuliaSyntaxHighlighting v1.12.0
  [4af54fe1] LazyArtifacts v1.11.0
  [b27032c2] LibCURL v0.6.4
  [76f85450] LibGit2 v1.11.0
  [8f399da3] Libdl v1.11.0
  [37e2e46d] LinearAlgebra v1.12.0
  [56ddb016] Logging v1.11.0
  [d6f4376e] Markdown v1.11.0
  [ca575930] NetworkOptions v1.3.0
  [44cfe95a] Pkg v1.12.1
  [de0858da] Printf v1.11.0
  [9abbd945] Profile v1.11.0
  [9a3f8284] Random v1.11.0
  [ea8e919c] SHA v0.7.0
  [9e88b42a] Serialization v1.11.0
  [2f01184e] SparseArrays v1.12.0
  [f489334b] StyledStrings v1.11.0
  [fa267f1f] TOML v1.0.3
  [a4e569a6] Tar v1.10.0
  [8dfed614] Test v1.11.0
  [cf7118a7] UUIDs v1.11.0
  [4ec0a83e] Unicode v1.11.0
  [e66e0078] CompilerSupportLibraries_jll v1.3.0+1
  [deac9b47] LibCURL_jll v8.15.0+0
  [e37daf67] LibGit2_jll v1.9.0+0
  [29816b5a] LibSSH2_jll v1.11.3+1
  [14a3606d] MozillaCACerts_jll v2025.11.4
  [4536629a] OpenBLAS_jll v0.3.29+0
  [05823500] OpenLibm_jll v0.8.7+0
  [458c3c95] OpenSSL_jll v3.5.4+0
  [bea87d4a] SuiteSparse_jll v7.8.3+2
  [83775a58] Zlib_jll v1.3.1+2
  [8e850b90] libblastrampoline_jll v5.15.0+0
  [8e850ede] nghttp2_jll v1.64.0+1
  [3f19e933] p7zip_jll v17.7.0+0
        Info Packages marked with ⌃ have new versions available and may be upgradable.
Precompiling for configuration --code-coverage=none --color=yes --check-bounds=yes --warn-overwrite=yes --depwarn=yes --inline=yes --startup-file=no --track-allocation=none
  ✗ TableTraits
  ✗ CodecZlib
  ✗ pixi_jll
Precompiling packages finished.
  42 dependencies successfully precompiled in 79 seconds. 34 already precompiled.
  1 dependency had output during precompilation:
┌ Hexaly
│      CondaPkg Found dev dependencies: /home/blegat/.julia/dev/Hexaly/CondaPkg.toml
│      CondaPkg Found dependencies: /home/blegat/.julia/packages/PythonCall/83z4q/CondaPkg.toml
│      CondaPkg Found dependencies: /home/blegat/.julia/packages/CondaPkg/8GjrP/CondaPkg.toml
│      CondaPkg Resolving changes
│               + libstdcxx
│               + libstdcxx-ng
│               + openssl
│               + pip
│               + python
│      CondaPkg Initialising pixi
│               │ /home/blegat/.julia/artifacts/cefba4912c2b400756d043a2563ef77a0088866b/bin/pixi
│               │ init
│               │ --format pixi
│               └ /tmp/jl_PtPsZg/.CondaPkg
│  ✔ Created /tmp/jl_PtPsZg/.CondaPkg/pixi.toml
│      CondaPkg Wrote /tmp/jl_PtPsZg/.CondaPkg/pixi.toml
│               │ [dependencies]
│               │ pip = "*"
│               │ openssl = ">=3, <3.6"
│               │ libstdcxx = ">=3.4,<=15.1"
│               │ libstdcxx-ng = ">=3.4,<=15.1"
│               │ 
│               │     [dependencies.python]
│               │     channel = "conda-forge"
│               │     build = "*cp*"
│               │     version = ">=3.10,!=3.14.0,!=3.14.1,<4, >=3.8"
│               │ 
│               │ [project]
│               │ name = ".CondaPkg"
│               │ platforms = ["linux-64"]
│               │ channels = ["conda-forge"]
│               │ channel-priority = "strict"
│               └ description = "automatically generated by CondaPkg.jl"
│      CondaPkg Installing packages
│               │ /home/blegat/.julia/artifacts/cefba4912c2b400756d043a2563ef77a0088866b/bin/pixi
│               │ install
│               └ --manifest-path /tmp/jl_PtPsZg/.CondaPkg/pixi.toml
│  ✔ The default environment has been installed.
└  
     Testing Running tests...
[ Info: Installing Hexaly Python package from pip.hexaly.com...
[ Info: Hexaly version: 14.5.0
[ Info: TSP optimal cost: 80
[ Info: Running test_HermitianPSDCone_basic
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_HermitianPSDCone_min_t
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_NormNuclearCone_VectorAffineFunction_with_transform
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_NormNuclearCone_VectorAffineFunction_without_transform
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_NormNuclearCone_VectorOfVariables_with_transform
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_NormNuclearCone_VectorOfVariables_without_transform
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_NormSpectralCone_VectorAffineFunction_with_transform
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_NormSpectralCone_VectorAffineFunction_without_transform
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_NormSpectralCone_VectorOfVariables_with_transform
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_NormSpectralCone_VectorOfVariables_without_transform
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_VectorNonlinearOracle_LagrangeMultipliers_MAX_SENSE
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_VectorNonlinearOracle_LagrangeMultipliers_MIN_SENSE
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_add_constrained_PositiveSemidefiniteConeTriangle
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_add_constrained_PositiveSemidefiniteConeTriangle_VariableName
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_add_constrained_PositiveSemidefiniteConeTriangle_VariablePrimalStart
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_attribute_AbsoluteGapTolerance
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_attribute_NodeLimit
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_attribute_NumberThreads
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_attribute_ObjectiveLimit
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_attribute_RawStatusString
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_attribute_RelativeGapTolerance
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_attribute_Silent
[ Info: Running test_attribute_SolutionLimit
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_attribute_SolveTimeSec
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_attribute_SolverName
[ Info: Running test_attribute_SolverVersion
[ Info: Running test_attribute_TimeLimitSec
[ Info: Running test_attribute_after_empty
[ Info: Running test_attribute_unsupported_constraint
[ Info: Running test_constraint_ConstraintDualStart
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_constraint_ConstraintPrimalStart
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_constraint_Indicator_ACTIVATE_ON_ONE
  Test errored with MathOptInterface.AddConstraintNotAllowed{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}
[ Info: Running test_constraint_Indicator_ACTIVATE_ON_ZERO
  Test errored with MathOptInterface.AddConstraintNotAllowed{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}
[ Info: Running test_constraint_Indicator_ConstraintName
  Test errored with MathOptInterface.AddConstraintNotAllowed{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}
[ Info: Running test_constraint_PrimalStart_DualStart_SecondOrderCone
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_constraint_ZeroOne_bounds
  Test errored with MathOptInterface.AddConstraintNotAllowed{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}
[ Info: Running test_constraint_ZeroOne_bounds_2
  Test errored with MathOptInterface.AddConstraintNotAllowed{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}
[ Info: Running test_constraint_ZeroOne_bounds_3
  Test errored with MathOptInterface.AddConstraintNotAllowed{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}
[ Info: Running test_constraint_qcp_duplicate_diagonal
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_constraint_qcp_duplicate_off_diagonal
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_cpsat_AllDifferent
[ Info: Running test_cpsat_BinPacking
  Test errored with MathOptInterface.AddConstraintNotAllowed{MathOptInterface.VariableIndex, MathOptInterface.Integer}
[ Info: Running test_cpsat_Circuit
[ Info: Running test_cpsat_CountAtLeast
[ Info: Running test_cpsat_CountBelongs
[ Info: Running test_cpsat_CountDistinct
[ Info: Running test_cpsat_CountGreaterThan
[ Info: Running test_cpsat_Cumulative
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_cpsat_Path
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_cpsat_ReifiedAllDifferent
  Test errored with MathOptInterface.AddConstraintNotAllowed{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}
[ Info: Running test_cpsat_Table
  Test errored with MathOptInterface.AddConstraintNotAllowed{MathOptInterface.VariableIndex, MathOptInterface.ZeroOne}
[ Info: Running test_model_ListOfConstraintsWithAttributeSet
[ Info: Running test_model_ListOfVariablesWithAttributeSet
[ Info: Running test_model_LowerBoundAlreadySet
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_model_Name
[ Info: Running test_model_ScalarFunctionConstantNotZero
[ Info: Running test_model_UpperBoundAlreadySet
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_model_VariableIndex_ConstraintName
[ Info: Running test_model_VariableName
[ Info: Running test_model_VariablePrimalStart
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_model_copy_to_UnsupportedAttribute
[ Info: Running test_model_copy_to_UnsupportedConstraint
[ Info: Running test_model_default_DualStatus
[ Info: Running test_model_default_ObjectiveSense
[ Info: Running test_model_default_PrimalStatus
[ Info: Running test_model_default_TerminationStatus
[ Info: Running test_model_delete
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_model_duplicate_VariableName
[ Info: Running test_model_empty
[ Info: Running test_model_is_valid
[ Info: Running test_model_show
[ Info: Running test_model_supports_constraint_ScalarAffineFunction_EqualTo
[ Info: Running test_model_supports_constraint_VariableIndex_EqualTo
[ Info: Running test_model_supports_constraint_VectorOfVariables_Nonnegatives
[ Info: Running test_multi_objective_solve_and_objective_value
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_affine_function
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_affine_function_delete
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_affine_function_delete_vector
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_affine_function_modify
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_nonlinear
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_nonlinear_delete
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_nonlinear_delete_vector
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_nonlinear_modify
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_of_variables
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_of_variables_delete
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_of_variables_delete_all
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_of_variables_delete_vector
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_quadratic_function
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_quadratic_function_delete
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_quadratic_function_delete_vector
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_multiobjective_vector_quadratic_function_modify
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_objective_ObjectiveFunction_blank
[ Info: Running test_objective_ObjectiveSense_FEASIBILITY_SENSE
[ Info: Running test_objective_ObjectiveSense_MAX_SENSE
[ Info: Running test_objective_ObjectiveSense_MIN_SENSE
[ Info: Running test_objective_ScalarAffineFunction_in_ListOfModelAttributesSet
[ Info: Running test_objective_ScalarQuadraticFunction_in_ListOfModelAttributesSet
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_objective_VariableIndex_in_ListOfModelAttributesSet
[ Info: Running test_objective_qp_ObjectiveFunction_edge_cases
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_objective_qp_ObjectiveFunction_zero_ofdiag
  Test errored with MathOptInterface.Test.RequirementUnmet
[ Info: Running test_variable_VariableName
[ Info: Running test_variable_get_VariableIndex
Test Summary: | Pass  Total   Time
Hexaly        |  128    128  44.7s
     Testing Hexaly tests passed
```